### PR TITLE
Optional rule for using 6-sided dice

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ You can either:
 - Play using only the forward firing guides and ignoring the wide arc, or
 - Roll an additional attack dice when the defender is in the forward firing guide.
 
+### D6 Rule
+
+Not everyone has a bucket of 8-sided dice in 2-3 colors readily available. With this optional rule common 6-sided dice are used instead. Attacks hit on a roll of 4-6. Defense cancels a hit on each roll of 4-6. There are no critical hits when using 6-sided dice.
+
 ## Game modes
 
 ### Team game


### PR DESCRIPTION
Using this optional rule obviously messes a bit with the probabilities, but I think it may be close enough. I thought of only allowing defense rolls to cancel a hit on a 5-6. Maybe that is better, to compensate for removing the critical hits? This could use some testing.
